### PR TITLE
feat: add category list component to main page

### DIFF
--- a/src/components/Common/GlobalStyle.tsx
+++ b/src/components/Common/GlobalStyle.tsx
@@ -2,7 +2,8 @@ import { css, Global } from '@emotion/react'
 import { FunctionComponent } from 'react'
 
 const defaultStyle = css`
-  @import url('https://fonts.googleapis.com/css2?family=Nanum+Myeongjo&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Nanum+Myeongjo:wght@400;700;800&display=swap');
+
   * {
     padding: 0;
     margin: 0;

--- a/src/components/Main/CategoryList.tsx
+++ b/src/components/Main/CategoryList.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled'
+import { Link } from 'gatsby'
+import { FunctionComponent, ReactNode } from 'react'
+
+type CategoryListProps = {
+  selectedCategory: string
+  categoryList: {
+    [key: string]: number
+  }
+}
+
+type CategoryItemProps = {
+  active: boolean
+}
+
+type GatsbyLinkProps = {
+  children: ReactNode
+  className?: string
+  to: string
+} & CategoryItemProps
+
+const CategoryItem = styled(({ active, ...props }: GatsbyLinkProps) => (
+  <Link {...props} />
+))`
+  margin-right: 20px;
+  padding: 5px 0px;
+  font-size: 18px;
+  font-weight: ${({ active }) => (active ? '800' : '400')};
+  color: ${({ active }) => (active ? 'red' : 'blue')};
+  cursor: pointer;
+
+  &:last-of-type {
+    margin-right: 0;
+  }
+`
+
+const CategoryListWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  width: 768px;
+  margin: 100px auto 0px;
+`
+
+const CategoryList: FunctionComponent<CategoryListProps> = function ({
+  selectedCategory,
+  categoryList,
+}) {
+  return (
+    <CategoryListWrapper>
+      {Object.entries(categoryList).map(([name, count]) => (
+        <CategoryItem
+          to={`/?category=${name}`}
+          active={name === selectedCategory}
+          key={name}
+        >
+          #{name}({count})
+        </CategoryItem>
+      ))}
+    </CategoryListWrapper>
+  )
+}
+
+export default CategoryList

--- a/src/components/Main/CategoryList.tsx
+++ b/src/components/Main/CategoryList.tsx
@@ -26,7 +26,6 @@ const CategoryItem = styled(({ active, ...props }: GatsbyLinkProps) => (
   padding: 5px 0px;
   font-size: 18px;
   font-weight: ${({ active }) => (active ? '800' : '400')};
-  color: ${({ active }) => (active ? 'red' : 'blue')};
   cursor: pointer;
 
   &:last-of-type {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,14 @@ import React, { FunctionComponent } from 'react'
 import GlobalStyle from 'components/Common/GlobalStyle'
 import styled from '@emotion/styled'
 import Introduction from 'components/Main/Introduction'
+import CategoryList from 'components/Main/CategoryList'
 import Footer from 'components/Common/Footer'
+
+const CATEGORY_LIST = {
+  ALL: 5,
+  Web: 3,
+  Mobile: 2,
+}
 
 const Container = styled.div`
   display: flex;
@@ -15,6 +22,7 @@ const IndexPage: FunctionComponent = function () {
     <Container>
       <GlobalStyle />
       <Introduction />
+      <CategoryList selectedCategory="Web" categoryList={CATEGORY_LIST} />
       <Footer />
     </Container>
   )


### PR DESCRIPTION
closes #8 
# Major changes
- Created a component `CategoryList` for filtering Blog Posts by its type. Currently there are 3 categories, ALL, Web, Mobile
  - Created a component `CategoryItem` inside CategoryList component file. If it becomes larger, I would separate it.
-  imported a google Font - `Nanum-Myeonjo` with 3 font weights (400,700,800) in `GlobalStyle` component
<img width="500" alt="image" src="https://user-images.githubusercontent.com/44149596/221096776-cab26836-b85e-4b94-b75d-54b70faa7e7f.png">

# TIL 
- Gatsby provides `Link` tag for routing pages. Among its functions, 