### PR TITLE
refactor : adapted media-query to components

### DIFF
--- a/src/components/Common/Footer.tsx
+++ b/src/components/Common/Footer.tsx
@@ -3,17 +3,16 @@ import { FunctionComponent } from 'react'
 
 const FooterWrapper = styled.div`
   display: grid;
-  grid-template-columns: 3;
-  grid-template-rows: 3;
-  column-gap: 1em;
-  row-gap: 1em;
-  align-items: center;
-  justify-content: center;
+  place-items: center;
   margin-top: auto;
   padding: 50px 0px;
   font-size: 15px;
   text-align: center;
   line-height: 1.5;
+
+  @media (max-width: 768px) {
+    font-size: 13px;
+  }
 `
 
 const Footer: FunctionComponent = function () {

--- a/src/components/Main/CategoryList.tsx
+++ b/src/components/Main/CategoryList.tsx
@@ -31,6 +31,10 @@ const CategoryItem = styled(({ active, ...props }: GatsbyLinkProps) => (
   &:last-of-type {
     margin-right: 0;
   }
+
+  @media (max-width: 768px) {
+    font-size: 15px;
+  }
 `
 
 const CategoryListWrapper = styled.div`
@@ -38,6 +42,12 @@ const CategoryListWrapper = styled.div`
   flex-wrap: wrap;
   width: 768px;
   margin: 100px auto 0px;
+
+  @media (max-width: 768px) {
+    width: 100%;
+    margin-top: 50px;
+    padding: 0 20px;
+  }
 `
 
 const CategoryList: FunctionComponent<CategoryListProps> = function ({

--- a/src/components/Main/Introduction.tsx
+++ b/src/components/Main/Introduction.tsx
@@ -16,17 +16,31 @@ const Wrapper = styled.div`
   width: 768px;
   height: 400px;
   margin: 0 auto;
+
+  @media (max-width: 768px) {
+    width: 100%;
+    height: 300px;
+    padding: 0 20px;
+  }
 `
 
 const SubTitle = styled.div`
   font-size: 20px;
   font-weight: 400;
+
+  @media (max-width: 768px) {
+    font-size: 15px;
+  }
 `
 
 const Title = styled.div`
   margin-top: 5px;
   font-size: 35px;
   font-weight: 700;
+
+  @media (max-width: 768px) {
+    font-size: 25px;
+  }
 `
 
 const Introduction: FunctionComponent = function () {

--- a/src/components/Main/PostItem.tsx
+++ b/src/components/Main/PostItem.tsx
@@ -4,7 +4,7 @@ import { FunctionComponent } from 'react'
 
 type PostItemProps = {
   title: string
-  data: string
+  date: string
   categories: string[]
   summary: string
   thumbnail: string
@@ -91,24 +91,14 @@ const PostItem: FunctionComponent<PostItemProps> = function ({
     <PostItemWrapper to={link}>
       <ThumbnailImage src={thumbnail} alt="Post Item Image" />
       <PostItemContent>
-        <Title>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Blanditiis
-          dolorum tempore qui illum hic aspernatur ut eos consequuntur
-          distinctio consectetur harum tenetur, reiciendis alias adipisci id et
-          voluptate, dignissimos dicta!
-        </Title>
-        <Date>2023.02.26</Date>
+        <Title>{title}</Title>
+        <Date>{date}</Date>
         <Category>
-          <CategoryItem>카테고리1</CategoryItem>
-          <CategoryItem>카테고리2</CategoryItem>
-          <CategoryItem>카테고리3</CategoryItem>
+          {categories.map(category => (
+            <CategoryItem key={category}>{category}</CategoryItem>
+          ))}
         </Category>
-        <Summary>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Iure quae
-          maxime asperiores. Laudantium ad neque dignissimos, non itaque aperiam
-          ab omnis delectus similique labore sunt laboriosam, amet voluptatum
-          voluptatibus voluptate!
-        </Summary>
+        <Summary>{summary}</Summary>
       </PostItemContent>
     </PostItemWrapper>
   )

--- a/src/components/Main/PostList.tsx
+++ b/src/components/Main/PostList.tsx
@@ -20,6 +20,12 @@ const PostListWrapper = styled.div`
   width: 768px;
   margin: 0 auto;
   padding: 50px 0 100px;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+    width: 100%;
+    padding: 50px 20px;
+  }
 `
 
 const PostList: FunctionComponent = function () {

--- a/src/components/Main/PostList.tsx
+++ b/src/components/Main/PostList.tsx
@@ -4,7 +4,7 @@ import PostItem from './PostItem'
 
 const POST_ITEM_DATA = {
   title: 'POST item title',
-  data: '2023.02.25',
+  date: '2023.02.25',
   categories: ['Web', 'Frontend', 'Testing'],
   summary: 'This is a fake post summary data',
   thumbnail:
@@ -25,6 +25,10 @@ const PostListWrapper = styled.div`
 const PostList: FunctionComponent = function () {
   return (
     <PostListWrapper>
+      <PostItem {...POST_ITEM_DATA} />
+      <PostItem {...POST_ITEM_DATA} />
+      <PostItem {...POST_ITEM_DATA} />
+      <PostItem {...POST_ITEM_DATA} />
       <PostItem {...POST_ITEM_DATA} />
     </PostListWrapper>
   )

--- a/src/components/Main/ProfileImage.tsx
+++ b/src/components/Main/ProfileImage.tsx
@@ -8,6 +8,11 @@ const ProfileImageWrapper = styled.img`
   height: 120px;
   margin-bottom: 30px;
   border-radius: 50%;
+
+  @media (max-width: 768px) {
+    width: 80px;
+    height: 80px;
+  }
 `
 
 const ProfileImage: FunctionComponent = function () {


### PR DESCRIPTION
closes #15

# Major improvements
- Adapt media-query to components for max-width 7689px;


https://user-images.githubusercontent.com/44149596/221561326-fd7c60c9-6899-444d-b8dd-2e7224a7e722.mov



# TIL
- Media query is a strong syntax for responsive design. However, if the number of components increases, even a small style change requirement can affect the entire component code, which might trigger human-errors. It's a little bit verbose and cumbersome ;)
- Better ways to manage responsive design are needed.


```
@media (max-width:768px){
  // styles when the browser is narrower than 768px width.
}
```
