### PR TITLE
feat: Visualize Markdown document as a page

### DIFF
--- a/contents/2023-02-01.md
+++ b/contents/2023-02-01.md
@@ -1,5 +1,5 @@
 ---
-date: '2023-02-08'
+date: '2023-02-01'
 title: 'MDTest'
 categories: ['All', 'SEO', 'Optimization']
 summary: '홈페이지를 운영하는 많은 사람들 또는 기업들이 검색 페이지 최상단에 보여지게 하기 위해 어떤 최적화 작업을 하는지 알아보자.'
@@ -18,7 +18,9 @@ Robots.txt 파일은 검색 엔진에 어떤 페이지를 크롤링해도 되는
 
 과도한 Robots.txt 파일은 더 많은 방문자를 유도할 수 있는 정상적인 검색 엔진 크롤러의 접근을 막을 가능성이 있기 때문에 적절하게 설정해야 한다.
 
----
+```javascript
+hello world!
+```
 
 ## Source
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "prismjs": "^1.29.0",
     "query-string": "^8.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-feather": "^2.0.10"
   },
   "devDependencies": {
     "@emotion/eslint-plugin": "^11.10.0",

--- a/src/components/Post/PostContent.tsx
+++ b/src/components/Post/PostContent.tsx
@@ -11,6 +11,80 @@ const MarkdownRenderer = styled.div`
   width: 768px;
   margin: 0 auto;
   padding: 100px 0;
+  word-break: break-all;
+
+  line-height: 1.8;
+  font-size: 16px;
+  font-weight: 400px;
+
+  p {
+    padding: 3px 0;
+  }
+
+  h1,
+  h2,
+  h3 {
+    font-weight: 800;
+    margin-bottom: 30px;
+  }
+
+  * + h1,
+  * + h2,
+  * + h2 {
+    margin-top: 80px;
+  }
+
+  hr + h1,
+  hr + h2,
+  hr + h2 {
+    margin-top: 0px;
+  }
+
+  h1 {
+    font-size: 30px;
+  }
+
+  h2 {
+    font-size: 25px;
+  }
+
+  h3 {
+    font-size: 20px;
+  }
+
+  blockquote {
+    margin: 30px 0;
+    padding: 5px 15px;
+    border-left: 2px solid black;
+    font-weight: 800;
+  }
+
+  ol,
+  ul {
+    margin-left: 20px;
+    padding: 30px 0;
+  }
+
+  a {
+    color: #4263eb;
+    text-decoration: underline;
+  }
+
+  pre[class*='language-'] {
+    margin: 30px 0;
+    padding: 15px;
+    font-size: 15px;
+
+    ::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.5);
+      border-radius: 3px;
+    }
+  }
+
+  code[class*='language-'],
+  pre[class*='language-'] {
+    tab-size: 2;
+  }
 `
 
 const PostContent: FunctionComponent<PostContentProps> = function ({ html }) {

--- a/src/components/Post/PostContent.tsx
+++ b/src/components/Post/PostContent.tsx
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled'
+import { FunctionComponent } from 'react'
+
+interface PostContentProps {
+  html: string
+}
+
+const MarkdownRenderer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 768px;
+  margin: 0 auto;
+  padding: 100px 0;
+`
+
+const PostContent: FunctionComponent<PostContentProps> = function ({ html }) {
+  return <MarkdownRenderer dangerouslySetInnerHTML={{ __html: html }} />
+}
+
+export default PostContent

--- a/src/components/Post/PostHead.tsx
+++ b/src/components/Post/PostHead.tsx
@@ -5,9 +5,12 @@ import {
   IGatsbyImageData,
 } from 'gatsby-plugin-image'
 import { FunctionComponent } from 'react'
-import { ArrowLeft } from 'react-feather'
+import PostHeadInfo from './PostHeadInfo'
 
 type PostHeadProps = {
+  title: string
+  date: string
+  categories: string[]
   thumbnail: IGatsbyImageData
 }
 
@@ -28,42 +31,16 @@ const BackgroundImage = styled((props: GatsbyImageProps) => (
   filter: brightness(0.25);
 `
 
-const RoundIconButton = styled.button`
-  display: grid;
-  place-items: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background: #ffffff;
-  color: #000000;
-  font-size: 22px;
-  cursor: pointer;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
-  &:hover {
-    transform: translateY(1%);
-    ::after {
-      position: absolute;
-      left: 110%;
-      border-radius: 10px;
-      content: 'Go Back';
-      font-size: 14px;
-      padding: 2px 10px;
-      color: white;
-      background-color: navy;
-      white-space: nowrap;
-    }
-  }
-`
-
-const PostHead: FunctionComponent<PostHeadProps> = function ({ thumbnail }) {
-  const goBackPage = () => window.history.back()
-
+const PostHead: FunctionComponent<PostHeadProps> = function ({
+  title,
+  date,
+  categories,
+  thumbnail,
+}) {
   return (
     <PostHeadWrapper>
       <BackgroundImage image={thumbnail} alt="thumbnail" />
-      <RoundIconButton onClick={goBackPage}>
-        <ArrowLeft size={24} />
-      </RoundIconButton>
+      <PostHeadInfo title={title} date={date} categories={categories} />
     </PostHeadWrapper>
   )
 }

--- a/src/components/Post/PostHead.tsx
+++ b/src/components/Post/PostHead.tsx
@@ -1,0 +1,71 @@
+import styled from '@emotion/styled'
+import {
+  GatsbyImage,
+  GatsbyImageProps,
+  IGatsbyImageData,
+} from 'gatsby-plugin-image'
+import { FunctionComponent } from 'react'
+import { ArrowLeft } from 'react-feather'
+
+type PostHeadProps = {
+  thumbnail: IGatsbyImageData
+}
+
+const PostHeadWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 400px;
+`
+
+const BackgroundImage = styled((props: GatsbyImageProps) => (
+  <GatsbyImage {...props} />
+))`
+  position: absolute;
+  z-index: -1;
+  width: 100%;
+  height: 400px;
+  object-fit: cover;
+  filter: brightness(0.25);
+`
+
+const RoundIconButton = styled.button`
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #ffffff;
+  color: #000000;
+  font-size: 22px;
+  cursor: pointer;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+  &:hover {
+    transform: translateY(1%);
+    ::after {
+      position: absolute;
+      left: 110%;
+      border-radius: 10px;
+      content: 'Go Back';
+      font-size: 14px;
+      padding: 2px 10px;
+      color: white;
+      background-color: navy;
+      white-space: nowrap;
+    }
+  }
+`
+
+const PostHead: FunctionComponent<PostHeadProps> = function ({ thumbnail }) {
+  const goBackPage = () => window.history.back()
+
+  return (
+    <PostHeadWrapper>
+      <BackgroundImage image={thumbnail} alt="thumbnail" />
+      <RoundIconButton onClick={goBackPage}>
+        <ArrowLeft size={24} />
+      </RoundIconButton>
+    </PostHeadWrapper>
+  )
+}
+
+export default PostHead

--- a/src/components/Post/PostHeadInfo.tsx
+++ b/src/components/Post/PostHeadInfo.tsx
@@ -1,0 +1,91 @@
+import styled from '@emotion/styled'
+import { FunctionComponent } from 'react'
+import { ArrowLeft } from 'react-feather'
+
+type PostHeadInfoProps = {
+  title: string
+  date: string
+  categories: string[]
+}
+
+const PostHeadInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 768px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 60px 0;
+  color: white;
+`
+
+const RoundIconButton = styled.button`
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #ffffff;
+  color: #000000;
+  font-size: 22px;
+  cursor: pointer;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+  &:hover {
+    transform: translateY(1%);
+    ::after {
+      position: absolute;
+      left: 110%;
+      border-radius: 10px;
+      content: 'Go Back';
+      font-size: 14px;
+      padding: 2px 10px;
+      color: white;
+      background-color: navy;
+      white-space: nowrap;
+    }
+  }
+`
+
+const Title = styled.div`
+  display: -webkit-box;
+  overflow: hidden;
+  overflow-wrap: break-word;
+  margin-top: auto;
+  text-overflow: ellipsis;
+  white-space: normal;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: 45px;
+  font-weight: 800;
+`
+
+const PostData = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 10px;
+  font-size: 18px;
+  font-weight: 700;
+`
+
+const PostHeadInfo: FunctionComponent<PostHeadInfoProps> = function ({
+  title,
+  date,
+  categories,
+}) {
+  const goBackPage = () => history.back()
+
+  return (
+    <PostHeadInfoWrapper>
+      <RoundIconButton onClick={goBackPage}>
+        <ArrowLeft size={24} />
+      </RoundIconButton>
+      <Title>{title}</Title>
+      <PostData>
+        <div>{categories.join(' / ')}</div>
+        <div>{date}</div>
+      </PostData>
+    </PostHeadInfoWrapper>
+  )
+}
+
+export default PostHeadInfo

--- a/src/templates/post_template.tsx
+++ b/src/templates/post_template.tsx
@@ -39,7 +39,12 @@ const PostTemplate: FunctionComponent<PostTemplateProps> = function ({
 
   return (
     <Template>
-      <PostHead thumbnail={gatsbyImageData} />
+      <PostHead
+        title={title}
+        date={date}
+        categories={categories}
+        thumbnail={gatsbyImageData}
+      />
       <button>button</button>
       Post Template
     </Template>

--- a/src/templates/post_template.tsx
+++ b/src/templates/post_template.tsx
@@ -1,12 +1,49 @@
 import Template from 'components/Common/Template'
+import PostHead from 'components/Post/PostHead'
 import { graphql } from 'gatsby'
 import { FunctionComponent } from 'react'
+import { PostFrontmatterType } from 'types/PostItem.types'
 
-type PostTemplateProps = {}
+export type PostPageItemType = {
+  node: {
+    html: string
+    frontmatter: PostFrontmatterType
+  }
+}
 
-const PostTemplate: FunctionComponent<PostTemplateProps> = function (props) {
-  console.log(props)
-  return <Template>Post Template</Template>
+type PostTemplateProps = {
+  data: {
+    allMarkdownRemark: { edges: PostPageItemType[] }
+  }
+}
+
+const PostTemplate: FunctionComponent<PostTemplateProps> = function ({
+  data: {
+    allMarkdownRemark: { edges },
+  },
+}) {
+  const {
+    node: {
+      html,
+      frontmatter: {
+        title,
+        summary,
+        date,
+        categories,
+        thumbnail: {
+          childImageSharp: { gatsbyImageData },
+        },
+      },
+    },
+  } = edges[0]
+
+  return (
+    <Template>
+      <PostHead thumbnail={gatsbyImageData} />
+      <button>button</button>
+      Post Template
+    </Template>
+  )
 }
 
 export default PostTemplate

--- a/src/templates/post_template.tsx
+++ b/src/templates/post_template.tsx
@@ -1,4 +1,5 @@
 import Template from 'components/Common/Template'
+import PostContent from 'components/Post/PostContent'
 import PostHead from 'components/Post/PostHead'
 import { graphql } from 'gatsby'
 import { FunctionComponent } from 'react'
@@ -45,7 +46,7 @@ const PostTemplate: FunctionComponent<PostTemplateProps> = function ({
         categories={categories}
         thumbnail={gatsbyImageData}
       />
-      <button>button</button>
+      <PostContent html={html} />
       Post Template
     </Template>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -9709,7 +9709,7 @@ prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -9893,6 +9893,13 @@ react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+
+react-feather@^2.0.10:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/react-feather/-/react-feather-2.0.10.tgz#0e9abf05a66754f7b7bb71757ac4da7fb6be3b68"
+  integrity sha512-BLhukwJ+Z92Nmdcs+EMw6dy1Z/VLiJTzEQACDUEnWMClhYnFykJCGWQx+NmwP/qQHGX/5CzQ+TGi8ofg2+HzVQ==
+  dependencies:
+    prop-types "^15.7.2"
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
closes #17 

# Major changes
- Render markdowns as a page
- Display markdown frontmatter data at the top of the page
- 
![Mar-17-2023 20-44-24](https://user-images.githubusercontent.com/44149596/225895519-2fe02557-40e3-4063-b569-44873d75db94.gif)


# TIL


- Codes in markdown are parsed to html `pre` and `code`
```javascript
<pre>
  <code>code <code>
</pre>

```

- Elements can be selected not only by classes, but also by attributes([link](https://www.w3schools.com/cssref/css_selectors.php))


